### PR TITLE
2019-01-30 release

### DIFF
--- a/src/api/DataApi.js
+++ b/src/api/DataApi.js
@@ -273,7 +273,7 @@ export function createOrMergeEntityData(entitySetId :UUID, entities :Object[]) :
  * @memberof lattice.DataApi
  * @param {UUID} entitySetId
  * @param {DeleteType} deleteType
- * @return {Promise} - a Promise that resolves with the count of entities that were updated
+ * @return {Promise} - a Promise that resolves with the count of entities that were deleted
  *
  * @example
  * DataApi.deleteAllEntitiesFromEntitySet(

--- a/src/api/DataApi.js
+++ b/src/api/DataApi.js
@@ -284,7 +284,7 @@ export function createOrMergeEntityData(entitySetId :UUID, entities :Object[]) :
 
 export function deleteAllEntitiesFromEntitySet(
   entitySetId :UUID,
-  deleteType :DeleteType = DeleteTypes.Soft
+  deleteType :DeleteType
 ) :Promise<*> {
 
   let errorMsg = '';

--- a/src/api/DataApi.js
+++ b/src/api/DataApi.js
@@ -29,6 +29,7 @@ import { getApiBaseUrl, getApiAxiosInstance } from '../utils/axios';
 import { isEmptyArray, isNonEmptyObject, isNonEmptyString } from '../utils/LangUtils';
 
 import {
+  ALL,
   ASSOCIATION_PATH,
   COUNT_PATH,
   FILE_TYPE,
@@ -302,7 +303,7 @@ export function deleteAllEntitiesFromEntitySet(
   }
 
   return getApiAxiosInstance(DATA_API)
-    .delete(`/${SET_PATH}/${entitySetId}/all?${TYPE_PATH}=${deleteType}`)
+    .delete(`/${SET_PATH}/${entitySetId}/${ALL}?${TYPE_PATH}=${deleteType}`)
     .then(axiosResponse => axiosResponse.data)
     .catch((error :Error) => {
       LOG.error(error);

--- a/src/api/DataApi.js
+++ b/src/api/DataApi.js
@@ -24,7 +24,7 @@ import DataGraph, { isValidDataGraph } from '../models/DataGraph';
 import FullyQualifiedName from '../models/FullyQualifiedName';
 import Logger from '../utils/Logger';
 import { DATA_API } from '../constants/ApiNames';
-import { UpdateTypes } from '../constants/types';
+import { UpdateTypes, DeleteTypes } from '../constants/types';
 import { getApiBaseUrl, getApiAxiosInstance } from '../utils/axios';
 import { isEmptyArray, isNonEmptyObject, isNonEmptyString } from '../utils/LangUtils';
 
@@ -263,6 +263,31 @@ export function createOrMergeEntityData(entitySetId :UUID, entities :Object[]) :
       return Promise.reject(error);
     });
 }
+
+/**
+ * `DELETE /data/set/{entitySetId}/all`
+ *
+ * // TODO: description
+ *
+ * @static
+ * @memberof lattice.DataApi
+ * @param {UUID} entitySetId
+ * @param {Object} entities
+ * @param {Boolean} partial
+ * @return {Promise} - a Promise that resolves with the count of entities that were updated
+ *
+ * @example
+ * DataApi.updateEntityData(
+  *   "0c8be4b7-0bd5-4dd1-a623-da78871c9d0e",
+  *   {
+  *     "219f0000-0000-0000-8000-000000000000": {
+  *       "8f79e123-3411-4099-a41f-88e5d22d0e8d": ["value_1", "value_2"],
+  *       "fae6af98-2675-45bd-9a5b-1619a87235a8": ["value_3", "value_4"]
+  *     }
+  *   },
+  *   false
+  * );
+  */
 
 /**
  * `GET /data/{entitySetId}/{entityKeyId}`

--- a/src/api/DataApi.js
+++ b/src/api/DataApi.js
@@ -510,7 +510,7 @@ export function getEntitySetSize(entitySetId :UUID) :Promise<*> {
  *       "fae6af98-2675-45bd-9a5b-1619a87235a8": ["value_3", "value_4"]
  *     }
  *   },
- *   false
+ *   'PartialReplace'
  * );
  */
 export function updateEntityData(entitySetId :UUID, entities :Object, updateType :UpdateType) :Promise<*> {

--- a/src/api/DataApi.test.js
+++ b/src/api/DataApi.test.js
@@ -4,7 +4,7 @@ import * as AxiosUtils from '../utils/axios';
 import * as DataApi from './DataApi';
 import { DATA_API } from '../constants/ApiNames';
 import { MOCK_DATA_EDGE_DM, MOCK_DATA_GRAPH_DM } from '../utils/testing/MockDataModels';
-import { UpdateTypes } from '../constants/types';
+import { UpdateTypes, DeleteTypes } from '../constants/types';
 
 import {
   ASSOCIATION_PATH,
@@ -63,6 +63,7 @@ describe('DataApi', () => {
   createAssociations();
   createEntityAndAssociationData();
   createOrMergeEntityData();
+  deleteAllEntitiesFromEntitySet();
   getEntityData();
   getEntitySetData();
   getEntitySetDataFileUrl();
@@ -165,6 +166,35 @@ function createOrMergeEntityData() {
     testApiShouldNotThrowOnInvalidParameters(apiToTest, validParams, invalidParams);
     testApiShouldRejectOnInvalidParameters(apiToTest, validParams, invalidParams);
     testApiShouldSendCorrectHttpRequest(apiToTest, validParams, axiosParams, 'post');
+  });
+}
+
+function deleteAllEntitiesFromEntitySet() {
+
+  describe('deleteAllEntitiesFromEntitySet()', () => {
+
+    const apiToTest = DataApi.deleteAllEntitiesFromEntitySet;
+    const mockEntitySetId = genRandomUUID();
+
+    const validParams = [mockEntitySetId, 'Soft'];
+    const invalidParams = [INVALID_PARAMS_SS, INVALID_PARAMS];
+
+    testApiShouldReturnPromise(apiToTest, validParams);
+    testApiShouldUseCorrectAxiosInstance(apiToTest, validParams, DATA_API);
+    testApiShouldNotThrowOnInvalidParameters(apiToTest, validParams, invalidParams);
+    testApiShouldRejectOnInvalidParameters(apiToTest, validParams, invalidParams);
+
+    test('type=Soft', () => {
+      const apiInvocationParams = [mockEntitySetId, 'Soft'];
+      const expectedAxiosParams = [`/${SET_PATH}/${mockEntitySetId}/all?${TYPE_PATH}=${DeleteTypes.Soft}`];
+      return assertApiShouldSendCorrectHttpRequest(apiToTest, apiInvocationParams, expectedAxiosParams, 'delete');
+    });
+
+    test('type=Hard', () => {
+      const apiInvocationParams = [mockEntitySetId, 'Hard'];
+      const expectedAxiosParams = [`/${SET_PATH}/${mockEntitySetId}/all?${TYPE_PATH}=${DeleteTypes.Hard}`];
+      return assertApiShouldSendCorrectHttpRequest(apiToTest, apiInvocationParams, expectedAxiosParams, 'delete');
+    });
   });
 }
 

--- a/src/api/DataApi.test.js
+++ b/src/api/DataApi.test.js
@@ -177,7 +177,7 @@ function deleteAllEntitiesFromEntitySet() {
     const mockEntitySetId = genRandomUUID();
 
     const validParams = [mockEntitySetId, 'Soft'];
-    const invalidParams = [INVALID_PARAMS_SS, INVALID_PARAMS];
+    const invalidParams = [INVALID_PARAMS_SS, INVALID_PARAMS_SS];
 
     testApiShouldReturnPromise(apiToTest, validParams);
     testApiShouldUseCorrectAxiosInstance(apiToTest, validParams, DATA_API);

--- a/src/constants/UrlConstants.js
+++ b/src/constants/UrlConstants.js
@@ -3,6 +3,7 @@
  */
 
 export const ADVANCED_PATH :string = 'advanced';
+export const ALL :string = 'all';
 export const ANALYSIS_PATH :string = 'analysis';
 export const APP_PATH :string = 'app';
 export const ASSOCIATION_PATH :string = 'association';

--- a/src/constants/UrlConstants.test.js
+++ b/src/constants/UrlConstants.test.js
@@ -5,6 +5,7 @@ import * as UrlConstants from './UrlConstants';
 /* eslint-disable key-spacing */
 const EXPECTED = Map({
   ADVANCED_PATH                 : 'advanced',
+  ALL                           : 'all',
   ANALYSIS_PATH                 : 'analysis',
   APP_PATH                      : 'app',
   ASSOCIATION_PATH              : 'association',

--- a/src/constants/types/DeleteTypes.js
+++ b/src/constants/types/DeleteTypes.js
@@ -1,0 +1,12 @@
+/*
+ * @flow
+ */
+
+const DeleteTypes = {
+  Hard: 'Hard',
+  Soft: 'Soft'
+};
+
+export type DeleteType = $Keys<typeof DeleteTypes>;
+
+export { DeleteTypes as default };

--- a/src/constants/types/DeleteTypes.test.js
+++ b/src/constants/types/DeleteTypes.test.js
@@ -1,0 +1,15 @@
+import { Map } from 'immutable';
+
+import DeleteTypes from './DeleteTypes';
+import { testEnumIntegrity } from '../../utils/testing/TestUtils';
+
+const EXPECTED_ENUM = Map({
+  Hard: 'Hard',
+  Soft: 'Soft'
+}).sortBy((value, key) => key);
+
+describe('DeleteTypes', () => {
+
+  testEnumIntegrity(DeleteTypes, EXPECTED_ENUM);
+
+});

--- a/src/constants/types/index.js
+++ b/src/constants/types/index.js
@@ -4,6 +4,7 @@
 
 import ActionTypes from './ActionTypes';
 import AnalyzerTypes from './AnalyzerTypes';
+import DeleteTypes from './DeleteTypes';
 import PermissionTypes from './PermissionTypes';
 import PrincipalTypes from './PrincipalTypes';
 import RequestStateTypes from './RequestStateTypes';
@@ -12,6 +13,7 @@ import UpdateTypes from './UpdateTypes';
 
 import type { Action } from './ActionTypes';
 import type { AnalyzerType } from './AnalyzerTypes';
+import type { DeleteType } from './DeleteTypes';
 import type { Permission } from './PermissionTypes';
 import type { PrincipalType } from './PrincipalTypes';
 import type { RequestState } from './RequestStateTypes';
@@ -21,6 +23,7 @@ import type { UpdateType } from './UpdateTypes';
 export {
   ActionTypes,
   AnalyzerTypes,
+  DeleteTypes,
   PermissionTypes,
   PrincipalTypes,
   RequestStateTypes,
@@ -31,6 +34,7 @@ export {
 export type {
   Action,
   AnalyzerType,
+  DeleteType,
   Permission,
   PrincipalType,
   RequestState,

--- a/src/index_default_export.test.js
+++ b/src/index_default_export.test.js
@@ -24,7 +24,7 @@ const EXPECTED_OBJ_EXPORTS = OrderedMap({
   SearchApi          : { size: 14 },
   Constants          : { size: 4 },
   Models             : { size: 45 },
-  Types              : { size: 7 },
+  Types              : { size: 8 },
 });
 /* eslint-enable key-spacing */
 

--- a/src/index_default_export.test.js
+++ b/src/index_default_export.test.js
@@ -12,7 +12,7 @@ const EXPECTED_OBJ_EXPORTS = OrderedMap({
   AnalysisApi        : { size: 2 },
   AppApi             : { size: 18 },
   AuthorizationApi   : { size: 2 },
-  DataApi            : { size: 14 },
+  DataApi            : { size: 15 },
   DataIntegrationApi : { size: 1 },
   EntityDataModelApi : { size: 61 },
   LinkingApi         : { size: 2 },

--- a/src/index_named_export.test.js
+++ b/src/index_named_export.test.js
@@ -24,11 +24,11 @@ const EXPECTED_OBJ_EXPORTS = OrderedMap({
   SearchApi          : { size: 14 },
   Constants          : { size: 4 },
   Models             : { size: 45 },
-  Types              : { size: 7 },
+  Types              : { size: 8 },
 });
 /* eslint-enable key-spacing */
 
-describe('lattice-js default export', () => {
+describe('lattice-js named export', () => {
 
   EXPECTED_OBJ_EXPORTS.forEach(({ size }, key) => {
     test(`should export "${key}`, () => {

--- a/src/index_named_export.test.js
+++ b/src/index_named_export.test.js
@@ -12,7 +12,7 @@ const EXPECTED_OBJ_EXPORTS = OrderedMap({
   AnalysisApi        : { size: 2 },
   AppApi             : { size: 18 },
   AuthorizationApi   : { size: 2 },
-  DataApi            : { size: 14 },
+  DataApi            : { size: 15 },
   DataIntegrationApi : { size: 1 },
   EntityDataModelApi : { size: 61 },
   LinkingApi         : { size: 2 },


### PR DESCRIPTION
DELETE /data/set/{entitySetId}/all

Deletes all entities from an entity set.

@static
@memberof lattice.DataApi
@param {UUID} entitySetId
@param {DeleteType} deleteType
@return {Promise} - a Promise that resolves with the count of entities that were deleted

@example

DataApi.deleteAllEntitiesFromEntitySet(
  "0c8be4b7-0bd5-4dd1-a623-da78871c9d0e",
  'Soft'
);