### PR TITLE
idsOnly prop to searchEntityNeighborsWithFilter

### DIFF
--- a/src/api/SearchApi.js
+++ b/src/api/SearchApi.js
@@ -30,12 +30,13 @@ import { isValidUUID, isValidUUIDArray } from '../utils/ValidationUtils';
 import {
   ADVANCED_PATH,
   FQN_PATH,
+  IDS_PATH,
   NEIGHBORS_PATH,
   ORGANIZATIONS_PATH,
+  SEARCH_ASSOCIATION_TYPES_PATH,
   SEARCH_ENTITY_SETS_PATH,
   SEARCH_ENTITY_TYPES_PATH,
-  SEARCH_ASSOCIATION_TYPES_PATH,
-  SEARCH_PROPERTY_TYPES_PATH
+  SEARCH_PROPERTY_TYPES_PATH,
 } from '../constants/UrlConstants';
 
 import {
@@ -969,10 +970,15 @@ export function searchEntityNeighbors(entitySetId :UUID, entityKeyId :UUID) :Pro
  *     "destinationEntitySetIds": ["11442cb3-99dc-4842-8736-6c76e6fcc7c4"],
  *     "edgeEntitySetIds": ["f8c6c56a-ad39-4587-b216-def81615d69c"],
  *     "sourceEntitySetIds": ["6317fab5-905d-42f4-8d67-2b78b3c56c77"],
- *   }
+ *   },
+ *   true
  * );
  */
-export function searchEntityNeighborsWithFilter(entitySetId :UUID, filter :Object) :Promise<*> {
+export function searchEntityNeighborsWithFilter(
+  entitySetId :UUID,
+  filter :Object,
+  idsOnly :boolean = false
+) :Promise<*> {
 
   let errorMsg = '';
   const data :Object = {};
@@ -980,6 +986,12 @@ export function searchEntityNeighborsWithFilter(entitySetId :UUID, filter :Objec
   if (!isValidUUID(entitySetId)) {
     errorMsg = 'invalid parameter: entitySetId must be a valid UUID';
     LOG.error(errorMsg, entitySetId);
+    return Promise.reject(errorMsg);
+  }
+
+  if (typeof idsOnly !== 'boolean') {
+    errorMsg = 'invalid parameter: idsOnly must be a boolean';
+    LOG.error(errorMsg, idsOnly);
     return Promise.reject(errorMsg);
   }
 
@@ -1039,8 +1051,11 @@ export function searchEntityNeighborsWithFilter(entitySetId :UUID, filter :Objec
     return Promise.reject(errorMsg);
   }
 
+  const baseEndpoint = `/${entitySetId}/${NEIGHBORS_PATH}/${ADVANCED_PATH}`;
+  const endpoint = idsOnly ? `${baseEndpoint}/${IDS_PATH}` : baseEndpoint;
+
   return getApiAxiosInstance(SEARCH_API)
-    .post(`/${entitySetId}/${NEIGHBORS_PATH}/${ADVANCED_PATH}`, data)
+    .post(endpoint, data)
     .then((axiosResponse) => axiosResponse.data)
     .catch((error :Error) => {
       LOG.error(error);

--- a/src/api/SearchApi.test.js
+++ b/src/api/SearchApi.test.js
@@ -8,6 +8,7 @@ import { genRandomString, genRandomUUID, getMockAxiosInstance } from '../utils/t
 import {
   ADVANCED_PATH,
   FQN_PATH,
+  IDS_PATH,
   NEIGHBORS_PATH,
   ORGANIZATIONS_PATH,
   SEARCH_ENTITY_TYPES_PATH,
@@ -16,6 +17,7 @@ import {
 
 import {
   INVALID_PARAMS,
+  INVALID_PARAMS_FOR_OPTIONAL_BOOLEAN,
   INVALID_PARAMS_FOR_OPTIONAL_SS_ARRAY,
   INVALID_PARAMS_SS,
 } from '../utils/testing/Invalid';
@@ -489,28 +491,56 @@ function searchEntityNeighborsWithFilter() {
   // TODO: test deduplicating arrays into sets
 
   describe('searchEntityNeighborsWithFilter', () => {
+    describe('default', () => {
+      const fnToTest = SearchApi.searchEntityNeighborsWithFilter;
+      const validParams = [MOCK_ENTITY_SET_ID, { entityKeyIds: [MOCK_ENTITY_KEY_ID] }];
+      const invalidParams = [
+        INVALID_PARAMS_SS,
+        {
+          destinationEntitySetIds: INVALID_PARAMS_FOR_OPTIONAL_SS_ARRAY,
+          edgeEntitySetIds: INVALID_PARAMS_FOR_OPTIONAL_SS_ARRAY,
+          entityKeyIds: INVALID_PARAMS_SS,
+          sourceEntitySetIds: INVALID_PARAMS_FOR_OPTIONAL_SS_ARRAY,
+        },
+      ];
+      const axiosParams = [
+        `/${MOCK_ENTITY_SET_ID}/${NEIGHBORS_PATH}/${ADVANCED_PATH}`,
+        { entityKeyIds: [MOCK_ENTITY_KEY_ID] },
+      ];
 
-    const fnToTest = SearchApi.searchEntityNeighborsWithFilter;
-    const validParams = [MOCK_ENTITY_SET_ID, { entityKeyIds: [MOCK_ENTITY_KEY_ID] }];
-    const invalidParams = [
-      INVALID_PARAMS_SS,
-      {
-        destinationEntitySetIds: INVALID_PARAMS_FOR_OPTIONAL_SS_ARRAY,
-        edgeEntitySetIds: INVALID_PARAMS_FOR_OPTIONAL_SS_ARRAY,
-        entityKeyIds: INVALID_PARAMS_SS,
-        sourceEntitySetIds: INVALID_PARAMS_FOR_OPTIONAL_SS_ARRAY,
-      },
-    ];
-    const axiosParams = [
-      `/${MOCK_ENTITY_SET_ID}/${NEIGHBORS_PATH}/${ADVANCED_PATH}`,
-      { entityKeyIds: [MOCK_ENTITY_KEY_ID] },
-    ];
+      testApiShouldReturnPromise(fnToTest, validParams);
+      testApiShouldUseCorrectAxiosInstance(fnToTest, validParams, SEARCH_API);
+      testApiShouldNotThrowOnInvalidParameters(fnToTest, validParams, invalidParams);
+      testApiShouldRejectOnInvalidParameters(fnToTest, validParams, invalidParams);
+      testApiShouldSendCorrectHttpRequest(fnToTest, validParams, axiosParams, 'post');
+      testApiShouldCatchRejectedPromise(fnToTest, validParams);
+    });
 
-    testApiShouldReturnPromise(fnToTest, validParams);
-    testApiShouldUseCorrectAxiosInstance(fnToTest, validParams, SEARCH_API);
-    testApiShouldNotThrowOnInvalidParameters(fnToTest, validParams, invalidParams);
-    testApiShouldRejectOnInvalidParameters(fnToTest, validParams, invalidParams);
-    testApiShouldSendCorrectHttpRequest(fnToTest, validParams, axiosParams, 'post');
-    testApiShouldCatchRejectedPromise(fnToTest, validParams);
+    describe('idsOnly = true', () => {
+      const fnToTest = SearchApi.searchEntityNeighborsWithFilter;
+      const validParams = [MOCK_ENTITY_SET_ID, { entityKeyIds: [MOCK_ENTITY_KEY_ID] }, true];
+      const invalidParams = [
+        INVALID_PARAMS_SS,
+        {
+          destinationEntitySetIds: INVALID_PARAMS_FOR_OPTIONAL_SS_ARRAY,
+          edgeEntitySetIds: INVALID_PARAMS_FOR_OPTIONAL_SS_ARRAY,
+          entityKeyIds: INVALID_PARAMS_SS,
+          sourceEntitySetIds: INVALID_PARAMS_FOR_OPTIONAL_SS_ARRAY,
+        },
+        INVALID_PARAMS_FOR_OPTIONAL_BOOLEAN
+      ];
+      const axiosParams = [
+        `/${MOCK_ENTITY_SET_ID}/${NEIGHBORS_PATH}/${ADVANCED_PATH}/${IDS_PATH}`,
+        { entityKeyIds: [MOCK_ENTITY_KEY_ID] },
+      ];
+
+      testApiShouldReturnPromise(fnToTest, validParams);
+      testApiShouldUseCorrectAxiosInstance(fnToTest, validParams, SEARCH_API);
+      testApiShouldNotThrowOnInvalidParameters(fnToTest, validParams, invalidParams);
+      testApiShouldRejectOnInvalidParameters(fnToTest, validParams, invalidParams);
+      testApiShouldSendCorrectHttpRequest(fnToTest, validParams, axiosParams, 'post');
+      testApiShouldCatchRejectedPromise(fnToTest, validParams);
+    });
+
   });
 }


### PR DESCRIPTION
# Changes
- add `idsOnly` prop to `searchEntityNeighborsWithFilter` that hits the following endpoint
  - https://github.com/openlattice/api/blob/develop/src/main/java/com/openlattice/search/SearchApi.java#L307

Until graph queries are functional, this allows devs to use the entityKeyIds returned from this endpoint in an advanced search that filters/sorts by property types without the overhead of unnecessary entity data.